### PR TITLE
fix: use resolved cert_path instead of param.cert_path in Server.__init__

### DIFF
--- a/pyjabber/server.py
+++ b/pyjabber/server.py
@@ -52,7 +52,7 @@ class Server:
         cert_path = param.cert_path or os.path.join(SERVER_FILE_PATH, "network", "certs")
         try:
             if not CertGenerator.check_hostname_cert_exists(param.host, cert_path):
-                CertGenerator.generate_hostname_cert(param.host, param.cert_path)
+                CertGenerator.generate_hostname_cert(param.host, cert_path)
         except FileNotFoundError as e:
             logger.error(f"{e.__class__.__name__}: Pass an existing directory in your system to load the certs. "
                          f"Closing protocols")


### PR DESCRIPTION
## Bug
When calling `spade run` without explicitly passing a cert path, `param.cert_path` is `None`.

In `server.py`, the code correctly resolves a fallback on line 53:
```python
cert_path = param.cert_path or os.path.join(SERVER_FILE_PATH, "network", "certs")
```
But line 55 still passes the unresolved `param.cert_path` to `generate_hostname_cert`:
```python
CertGenerator.generate_hostname_cert(param.host, param.cert_path)  
```
This causes:
```
TypeError: chdir: path should be string, bytes, os.PathLike or integer, not NoneType
```

## Fix
Pass the resolved `cert_path` variable instead:
```python
CertGenerator.generate_hostname_cert(param.host, cert_path)  
```

## Reproduction
```bash
pip install "spade>=4.0.0rc1"
spade run --host localhost  # crashes immediately
```