### PR TITLE
Hotfix + minor refact

### DIFF
--- a/pyjabber/db/database.py
+++ b/pyjabber/db/database.py
@@ -80,7 +80,7 @@ class DB:
 
         if os.path.isfile(AppConfig.app_config.database_path):
             DB._engine = create_async_engine(
-                url="sqlite+aiosqlite:///tickets.db",
+                url=f"sqlite+aiosqlite:///{AppConfig.app_config.database_path}",
                 echo=AppConfig.app_config.database_debug
             )
 

--- a/pyjabber/network/protocols/XMLProtocol.py
+++ b/pyjabber/network/protocols/XMLProtocol.py
@@ -70,7 +70,7 @@ class XMLProtocol(asyncio.Protocol):
         :type transport: asyncio.Transport
         """
         self._peer = transport.get_extra_info('peername')
-        logger.info(f"{"Server c" if self._server_incoming else "C"}onnection from <{self._peer}>")
+        logger.info(f"{'Server c' if self._server_incoming else 'C'}onnection from <{self._peer}>")
 
         if self._connection_timeout:
             self._timeout_monitor = StreamAlivenessMonitor(
@@ -121,7 +121,7 @@ class XMLProtocol(asyncio.Protocol):
         if self._timeout_flag:
             return
 
-        logger.info(f"Connection lost <{self._peer}>{f": Reason {exc}" if exc else ""}")
+        logger.info(f"Connection lost <{self._peer}>{f'': Reason {exc}' if exc else ''}")
 
         self._transport = None
         self._xml_parser.getContentHandler().cancel_queue_bridge()

--- a/pyjabber/queues/FailedRemoteConnection.py
+++ b/pyjabber/queues/FailedRemoteConnection.py
@@ -1,10 +1,11 @@
+from dataclasses import dataclass
 
+
+@dataclass(frozen=True, slots=True)
 class FailedRemoteConnectionWrapper:
     """
     Represents a S2S connection failure.
     Notifies to the client with pending messages to the remote server
     """
-    __slots__ = ('value', 'reason')
-    def __init__(self, value, reason):
-        self.value = value
-        self.reason = reason
+    value: str
+    reason: str

--- a/pyjabber/queues/NewConnection.py
+++ b/pyjabber/queues/NewConnection.py
@@ -1,9 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
 class NewConnectionWrapper:
     """
     Represents a new connection made.
     It can be from a client or a server.
     """
-    __slots__ = ('value', 'client')
-    def __init__(self, value, client=True):
-        self.value = value
-        self.client = client
+    value: str
+    client: bool


### PR DESCRIPTION
- Fix the use of nested double quotes in the f-string to keep compability with python versions <= 3.12
- Fix database connection error. In the case that a database file path is set, the db initializer will use a value hardcoded (tickets.db)
- Refact the wrappers of the messages in the workers queues. Used dataclass (frozen + slots)