### PR TITLE
fix(pubsub): await memory refresh after node/subscription updates

### DIFF
--- a/pyjabber/plugins/xep_0060/xep_0060.py
+++ b/pyjabber/plugins/xep_0060/xep_0060.py
@@ -156,7 +156,7 @@ class PubSub(metaclass=Singleton):
             if not AppConfig.app_config.database_in_memory:
                 await con.commit()
 
-        self.update_memory_from_database()
+        await self.update_memory_from_database()
 
         iq_res, pubsub = success_response(element)
         ET.SubElement(pubsub, "create", attrib={"node": new_node})
@@ -197,7 +197,7 @@ class PubSub(metaclass=Singleton):
             if not AppConfig.app_config.database_in_memory:
                 await con.commit()
 
-        self.update_memory_from_database()
+        await self.update_memory_from_database()
         iq_res, _ = success_response(element)
         return ET.tostring(iq_res)
 
@@ -335,7 +335,7 @@ class PubSub(metaclass=Singleton):
             if not AppConfig.app_config.database_in_memory:
                 await con.commit()
 
-        self.update_memory_from_database()
+        await self.update_memory_from_database()
 
         iq_res, pubsub = success_response(element)
         ET.SubElement(
@@ -416,7 +416,7 @@ class PubSub(metaclass=Singleton):
             if not AppConfig.app_config.database_in_memory:
                 await con.commit()
 
-        self.update_memory_from_database()
+        await self.update_memory_from_database()
 
         iq_res, pubsub = success_response(element)
         sub = ET.SubElement(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyjabber"
-version = "0.4.2"
+version = "0.4.5"
 description = "A lightweight, modular and asyncio XMPP/Jabber server written in Python."
 readme = "README.rst"
 requires-python = ">=3.9"


### PR DESCRIPTION
- Adds missing `await` to `update_memory_from_database()` in create/delete node and subscribe/unsubscribe flows.
- Fixes un-awaited coroutine behavior and keeps pubsub in-memory state consistent.
- Bumps project version to `0.4.5` (aligned with SPADE `4.1.3`).