### PR TITLE
fix: xep_0060 stability updates (await, dedup, create_node idempotency) + metadata version bump

### DIFF
--- a/pyjabber/plugins/xep_0060/xep_0060.py
+++ b/pyjabber/plugins/xep_0060/xep_0060.py
@@ -156,7 +156,7 @@ class PubSub(metaclass=Singleton):
             if not AppConfig.app_config.database_in_memory:
                 await con.commit()
 
-        self.update_memory_from_database()
+        await self.update_memory_from_database()
 
         iq_res, pubsub = success_response(element)
         ET.SubElement(pubsub, "create", attrib={"node": new_node})
@@ -197,7 +197,7 @@ class PubSub(metaclass=Singleton):
             if not AppConfig.app_config.database_in_memory:
                 await con.commit()
 
-        self.update_memory_from_database()
+        await self.update_memory_from_database()
         iq_res, _ = success_response(element)
         return ET.tostring(iq_res)
 
@@ -335,7 +335,7 @@ class PubSub(metaclass=Singleton):
             if not AppConfig.app_config.database_in_memory:
                 await con.commit()
 
-        self.update_memory_from_database()
+        await self.update_memory_from_database()
 
         iq_res, pubsub = success_response(element)
         ET.SubElement(
@@ -416,7 +416,7 @@ class PubSub(metaclass=Singleton):
             if not AppConfig.app_config.database_in_memory:
                 await con.commit()
 
-        self.update_memory_from_database()
+        await self.update_memory_from_database()
 
         iq_res, pubsub = success_response(element)
         sub = ET.SubElement(

--- a/pyjabber/plugins/xep_0060/xep_0060.py
+++ b/pyjabber/plugins/xep_0060/xep_0060.py
@@ -697,7 +697,16 @@ class PubSub(metaclass=Singleton):
             if payload is not None:
                 item.append(payload)
 
+        # A single transport may appear more than once in the receivers list.
+        # Send the event only once per transport to avoid duplicate notifications.
+        # Root cause should be tracked/fixed in upstream issue (ID #74).
+        seen_transports: set[int] = set()
         for jid, buffer, _ in receivers_buffer_single_iterator:
+            buf_id = id(buffer)
+            if buf_id in seen_transports:
+                continue
+            seen_transports.add(buf_id)
+
             message = Message(
                 mto=jid.bare(),
                 mfrom=AppConfig.app_config.host,

--- a/pyjabber/plugins/xep_0060/xep_0060.py
+++ b/pyjabber/plugins/xep_0060/xep_0060.py
@@ -147,6 +147,9 @@ class PubSub(metaclass=Singleton):
             if existing:
                 existing_owner = existing[0][NodeAttrib.OWNER.value]
                 if existing_owner == jid.user:
+                    logger.warning(
+                        f"create_node: node '{new_node}' already exists and owner matches {jid.user}; treating as idempotent"
+                    )
                     # Temporary behavior: if the node already exists for the same owner,
                     # return success instead of conflict. This should be revisited against
                     # the XEP-0060 expected behavior before considering it final.

--- a/pyjabber/plugins/xep_0060/xep_0060.py
+++ b/pyjabber/plugins/xep_0060/xep_0060.py
@@ -135,22 +135,35 @@ class PubSub(metaclass=Singleton):
         if not new_node:
             return error_response(element, jid, ErrorType.NOT_ACCEPTABLE)
 
-        # Node already exists
-        if [node for node in self._nodes if node[NodeAttrib.NODE.value] == new_node]:
-            return error_response(element, jid, ErrorType.CONFLICT)
-
         if config:  # pragma: no cover
             pass  # TODO: create node with given configuration
 
-        item = {
-            "node": new_node,
-            "owner": jid.user,
-            "name": None,
-            "type": "leaf",
-            "max_items": 1024,
-        }
-
         async with await DB.connection_async() as con:
+            # Check DB state first to avoid races with in-memory cache.
+            sel = select(Model.Pubsub).where(Model.Pubsub.c.node == new_node)
+            res = await con.execute(sel)
+            existing = res.fetchall()
+
+            if existing:
+                existing_owner = existing[0][NodeAttrib.OWNER.value]
+                if existing_owner == jid.user:
+                    # Temporary behavior: if the node already exists for the same owner,
+                    # return success instead of conflict. This should be revisited against
+                    # the XEP-0060 expected behavior before considering it final.
+                    iq_res, pubsub = success_response(element)
+                    ET.SubElement(pubsub, "create", attrib={"node": new_node})
+                    return ET.tostring(iq_res)
+
+                return error_response(element, jid, ErrorType.CONFLICT)
+
+            item = {
+                "node": new_node,
+                "owner": jid.user,
+                "name": None,
+                "type": "leaf",
+                "max_items": 1024,
+            }
+
             query = insert(Model.Pubsub).values(item)
             await con.execute(query)
             if not AppConfig.app_config.database_in_memory:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyjabber"
-version = "0.4.2"
+version = "0.4.5"
 description = "A lightweight, modular and asyncio XMPP/Jabber server written in Python."
 readme = "README.rst"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "loguru>=0.7.3",
     "nanoid>=2.0.0",
     "pyyaml>=6.0.3",
-    "sqlalchemy>=2.0.46",
+    "sqlalchemy[asyncio]>=2.0.46",
     "uvloop>=0.21.0; sys_platform != 'win32'",
     "winloop>=0.5.0; sys_platform == 'win32'",
 ]


### PR DESCRIPTION
## Summary

This PR ports and structures a set of XEP-0060 related fixes that were previously tested locally:

1. Await `update_memory_from_database` in async paths.
2. Deduplicate pubsub notification fanout per transport.
3. Adjust `create_node` behavior to avoid conflict when the node already exists for the same owner (temporary behavior, pending standards review).
4. Add warning log for the idempotent `create_node` path.
5. Bump `pyproject.toml` metadata version to `0.4.5` so editable installs resolve correctly with SPADE 4.1.4 (`pyjabber>=0.4.3`).

## Commits included

- `fix: await update_memory_from_database`
- `fix: deduplicate pubsub notifications by transport`
- `fix: create_node modification to allow existing nodes from same owner`
- `chore: add warning for idempotent create_node path`
- `fix: bump pyjabber project version metadata to 0.4.5`

## Notes

- The deduplication guard includes a comment referencing upstream issue #74 for root-cause follow-up.
- This PR intentionally keeps the changes split into small, reviewable commits.
